### PR TITLE
Passing opts to /usr/bin/env fails on linux

### DIFF
--- a/exe/cfme-versions
+++ b/exe/cfme-versions
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby --disable-gems
+#!/usr/bin/env ruby
 #
 # A "sans *.rb" bin stub file for `cfme-versions.rb` program
 #


### PR DESCRIPTION
Passing options to /usr/bin/env in a shebang like this fails on linux.

```
$ bundle exec exe/cfme-versions
/usr/bin/env: ‘ruby --disable-gems’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```