### PR TITLE
Add the versions table to the README for quick access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 Command line utility and library for viewing versions across CloudForms (CF),
 CloudForms Management Engine (CFME), and ManageIQ (MIQ).
 
+```
++----------------+------------------------------+------------+-------+-------+------------+
+| MANAGEIQ       | CLOUDFORMS MANAGEMENT ENGINE | CLOUDFORMS | RUBY  | RAILS | POSTGRESQL |
++----------------+------------------------------+------------+-------+-------+------------+
+|                | 5.1.z                        | 2.0        |       |       |            |
+|                | 5.2.z                        | 3.0        |       |       |            |
+| Anand          | 5.3.z                        | 3.1        |       |       |            |
+| Botvinnik      | 5.4.z                        | 3.1        |       |       |            |
+| Capablanca     | 5.5.z                        | 4.0        | 2.2.z | 4.2.z | 9.4.z      |
+| Darga          | 5.6.z                        | 4.1        | 2.2.z | 5.0.z | 9.4.z      |
+| Euwe           | 5.7.z                        | 4.1        | 2.3.z | 5.0.z | 9.5.z      |
+| Fine           | 5.8.z                        | 4.5        | 2.3.z | 5.0.z | 9.5.z      |
+| Gaprindashvili | 5.9.z                        | 4.6        | 2.3.z | 5.0.z | 9.5.z      |
+| Hammer         | 5.10.z                       | 4.7        | 2.4.z | 5.0.z | 9.5.z      |
+| Ivanchuk       | 5.11.z                       | 5.0        | 2.5.z | 5.1.z | 10.y       |
+| Jansa          | 5.12.z                       | 5.1        | 2.5.z | 5.2.z | 10.y       |
++----------------+------------------------------+------------+-------+-------+------------+
+```
 
 Requirements
 ------------


### PR DESCRIPTION
Maintain compatibility with chrisarcand/miqversion :)

Add the versions table to the README so people can quickly view it
without having to install the gem

This will have to be updated when the versions table is modified.