### PR TITLE
Gem versioning clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ most recent numeric version of ManageIQ.  However, in the case of bug fixes,
 patch versions might be included.
 
 In the cases where a patch is needed, just update the `CFME::Versions.version`
-to set the version directly. When a new version is released, reset it back to 0
-for consistency.
+to set the version directly. When a new version is released, reset the end of
+the string to `+ ".0.0"` for consistency.
 
 Note:  Previously the CFME version number was used to version this gem, but
 since that is reaching EOL the decision was made to use the upstream

--- a/lib/cfme-versions.rb
+++ b/lib/cfme-versions.rb
@@ -71,8 +71,7 @@ module CFME
 
       # Version of this gem/tool
       def version
-        numbers = versions.last.miq_semver.split(".").select { |val| val =~ /^\d+$/ } + %w[0 0 0]
-        numbers.first(3).join(".")
+        versions.last.miq_semver.split(".").first + ".0.0"
       end
 
       def versions


### PR DESCRIPTION
Makes two changes based off of the changes introduced in #10 and #11:

- Updates the `README.md` with a note regarding the jump in version numbers
- Updates the `CFME::Versions.version` logic to be more clear, and adjusts `README.md` instructions to match the simplification.

More detailed explainations included in the commit messages.